### PR TITLE
Improved error handling in Perl wrapper code

### DIFF
--- a/src/clients/perl/Crypt-LibSCEP/t/Crypt-LibSCEP.t
+++ b/src/clients/perl/Crypt-LibSCEP/t/Crypt-LibSCEP.t
@@ -331,6 +331,9 @@ my $certrep_success_crl_unwrapped = Crypt::LibSCEP::unwrap($conf, $certrep_succe
 ok($certrep_success_crl_unwrapped ne "", "CertRep SUCCESS CRL unwrap");
 ok(Crypt::LibSCEP::get_crl($certrep_success_crl_unwrapped) eq $crl, "CertRep SUCCESS crl");
 
+#### my $certrep_success_crl = Crypt::LibSCEP::create_crl_reply($ca_conf2, $sig_cakey_enc, $sig_cacert, $getcrl, $crl);
+
+
 #Testing create_nextca_reply
 ok(Crypt::LibSCEP::create_nextca_reply($conf, $issuedCert . "\n" . $sig_cacert, $sig_cacert, $sig_cakey) ne "", "create_nextca_reply");
 


### PR DESCRIPTION
This commit addresses memory allocation problems when dealing with errorneous input data on the Perl level. Instead of throwing SIGSEGV we now die (somewhat) gracefully.