### PR TITLE
Replace PKCS7_decrypt with CMS_decrypt

### DIFF
--- a/src/scep.h.in
+++ b/src/scep.h.in
@@ -10,6 +10,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/evp.h>
+#include <openssl/cms.h>
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>


### PR DESCRIPTION
There is a known problem with `PKCS7_decrypt` method which is **unable** to decrypt PKCS7 payload where RSA is used together with [OAEP](https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding) padding. This problem was originally [discovered](https://stackoverflow.com/questions/56941480/how-to-set-padding-oaep-for-pkcs7-decrypt-function-using-openssl) by developer [Unome](https://stackoverflow.com/users/3803253/unome). After the VMware configured (late march 2021) their SCEP client in Workspace ONE UEM to use RSA with OAEP padding `libscep` couldn't unwrap the PKCS7 message anymore. I was able to confirm Unomes findings and prove `PKCS7_decrypt` was indeed unable to decrypt RSA with OAEP padding. I discussed this in OpenSSL user [mailing list](https://mta.openssl.org/pipermail/openssl-users/2021-April/013669.html) (Read the entire thread).

This PR is a workaround which converts the `PKCS7` struct into `CMS_ContentInfo` struct just before decryption. After that we can use `CMS_decrypt` to successfully decrypt the content.

Please note I am unable to compile `test_util` test and `test_message` test fails with segmentation fault (before this PR is applied). If you have any internal tests not available in this repo please use them to check if my changes are OK. I can confirm OpenXPKI is now able to issue the certificate for the VMware WSO UEM SCEP client.